### PR TITLE
Bump PHP 8.* version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "composer-plugin",
     "license": "OSL-3.0",
     "require": {
-        "php": "^7.2",
+        "php": "^7.2||^8.1",
         "ext-json": "*",
         "composer-plugin-api": "^1.0||^2.0",
         "composer/composer": "^1.10||^2.0"


### PR DESCRIPTION
Hi @shiftedreality,

This PR aims to solve an issue we have experienced recently when trying to deploy 2.4.6 to our cloud environment. This is the exact error message we've got:

```bash
Executing build hook...
        W: Warning: You should avoid overwriting already defined auth settings for github.com.
        W: Installing dependencies from lock file (including require-dev)
        W: Verifying lock file contents can be installed on current platform.
        W: Your lock file does not contain a compatible set of packages. Please run composer update.
        W:
        W:   Problem 1
        W:     - magento/magento-vcs-installer is locked to version 1.0.3 and an update of this package was not requested.
        W:     - magento/magento-vcs-installer 1.0.3 requires php ^7.2||~8.1.0 -> your php version (8.2.3) does not satisfy that requirement.
        W:

      E: Error building project: Step failed with status code 2.

    E: Error: Unable to build application, aborting.
```

I solved an issue by manually bumping PHP version for `magento/magento-vcs-installer` directly in `composer.lock` and it worked:

<img width="1354" alt="image" src="https://user-images.githubusercontent.com/3187617/232472189-40326d2d-4887-481f-b510-01cb4de3101f.png">


My guess is updating the version in `composer.json` of `magento/magento-vcs-installer` is the correct way to fix the problem, but feel free to implement any solution necessary.

Cheers,
Rafal Janicki
Iberian Lynxes

